### PR TITLE
Added ability to override close button div class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ src/*.ngfactory.ts
 angular2-toaster.d.ts
 demo/webpack/bundle.js
 demo/webpack/bundle.js.map
+*.d.ts
+angular5-toaster-*.tgz

--- a/src/toast.component.ts
+++ b/src/toast.component.ts
@@ -17,7 +17,7 @@ import {BodyOutputType} from './bodyOutputType';
                 <div *ngSwitchCase="bodyOutputType.Default">{{toast.body}}</div>
             </div>
         </div>
-        <div class="toast-close-button" *ngIf="toast.showCloseButton" (click)="click($event, toast)"
+        <div [ngClass]="toast.closeDivClass" *ngIf="toast.showCloseButton" (click)="click($event, toast)"
             [innerHTML]="safeCloseHtml">
         </div>`
 })
@@ -42,8 +42,19 @@ export class ToastComponent implements OnInit, AfterViewInit {
     ) {}
 
     ngOnInit() {
+        // Not sanitizing the close button html
         if (this.toast.closeHtml) {
             this.safeCloseHtml = this.sanitizer.bypassSecurityTrustHtml(this.toast.closeHtml);
+        }
+
+        // Default the close button div tag class if one isn't passed or configured
+        if (this.toast.showCloseButton && !this.toast.closeDivClass) {
+            if (this.toast.toasterConfig) {
+                this.toast.closeDivClass = this.toast.toasterConfig.closeDivClass ?
+                    this.toast.toasterConfig.closeDivClass : 'toast-close-button';
+            } else {
+                this.toast.closeDivClass = 'toast-close-button';
+            }
         }
     }
 

--- a/src/toast.component.ts
+++ b/src/toast.component.ts
@@ -49,9 +49,8 @@ export class ToastComponent implements OnInit, AfterViewInit {
 
         // Default the close button div tag class if one isn't passed or configured
         if (this.toast.showCloseButton && !this.toast.closeDivClass) {
-            if (this.toast.toasterConfig) {
-                this.toast.closeDivClass = this.toast.toasterConfig.closeDivClass ?
-                    this.toast.toasterConfig.closeDivClass : 'toast-close-button';
+            if (this.toast.toasterConfig && this.toast.toasterConfig.closeDivClass) {
+                this.toast.closeDivClass = this.toast.toasterConfig.closeDivClass;
             } else {
                 this.toast.closeDivClass = 'toast-close-button';
             }

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -15,6 +15,7 @@ export interface Toast {
     clickHandler?: ClickHandler;
     showCloseButton?: boolean;
     closeHtml?: string;
+    closeDivClass?: string;
     toasterConfig?: ToasterConfig;
     data?: any;
 }

--- a/src/toaster-config.ts
+++ b/src/toaster-config.ts
@@ -5,6 +5,7 @@ export class ToasterConfig implements IToasterConfig {
     tapToDismiss: boolean;
     showCloseButton: boolean|Object;
     closeHtml: string;
+    closeDivClass: string;
     newestOnTop: boolean;
     timeout: number|Object;
     typeClasses: Object;
@@ -32,6 +33,7 @@ export class ToasterConfig implements IToasterConfig {
         this.closeHtml = configOverrides.closeHtml || '<button class="toast-close-button" type="button">&times;</button>';
         this.newestOnTop = configOverrides.newestOnTop != null ? configOverrides.newestOnTop : true;
         this.timeout = configOverrides.timeout != null ? configOverrides.timeout : 5000;
+        this.closeDivClass = configOverrides.closeDivClass != null ? configOverrides.closeDivClass : 'toast-close-button';
         this.typeClasses = configOverrides.typeClasses || {
             error: 'toast-error',
             info: 'toast-info',
@@ -64,6 +66,7 @@ export interface IToasterConfig {
     tapToDismiss?: boolean;
     showCloseButton?: boolean|Object;
     closeHtml?: string;
+    closeDivClass?: string,
     newestOnTop?: boolean;
     timeout?: number|Object;
     typeClasses?: Object;


### PR DESCRIPTION
* Added to toaster-config to allow for default configuration for a given toaster-container
* Added to toast to allow for individual overrides on a pop
* Retained absolute default of 'toast-close-button'
* Added a couple more .gitignore entries based local build elements.